### PR TITLE
Add trmnl-plugins skill for TRMNL e-ink dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ npx skills add asebesta/claude-skills/<skill-name>
 | [ios-app-store-competitor-research](./ios-app-store-competitor-research) | Extract app metadata and screenshots from Apple App Store listings for competitive analysis |
 | [paligo-api](./paligo-api) | Paligo CCMS REST API reference for content round-trips: tree walking, pulling/editing/validating/pushing topic XML, checkout, release status, and translations |
 | [veo-video](./veo-video) | Generate videos using Google's Veo 3.1 API via the @google/genai SDK |
+| [trmnl-plugins](./trmnl-plugins) | Build custom private plugins and dashboards for TRMNL e-ink displays (incl. TRMNL X): data strategies, Liquid templating, and Design Framework 3.1 markup |
 | [virtuous-api](./virtuous-api) | Virtuous CRM API integration reference for donor management features |
 
 ### blackbaud-renxt-api
@@ -120,6 +121,21 @@ npx skills add asebesta/claude-skills/virtuous-api
 - Code involving Virtuous API integration
 - Donor management features using Virtuous
 - Questions about Virtuous endpoints, authentication, or data models
+
+### trmnl-plugins
+
+Build custom private plugins and dashboards for TRMNL e-ink displays, including the TRMNL X (10.3", 1872×1404, 16-level grayscale). Covers the data layer (webhook push, polling, plugin-merge), Liquid templating with TRMNL's custom filters, and the Design Framework 3.1 markup (views, mashups, items, tables, charts, typography, responsive/bit-depth utilities). Includes copy-paste layout scaffolds and chart/dashboard recipes.
+
+**Install:**
+```bash
+npx skills add asebesta/claude-skills/trmnl-plugins
+```
+
+**Triggers on:**
+- Creating or editing a TRMNL private plugin or dashboard
+- Writing plugin markup/Liquid or sending data via webhook or polling
+- Designing TRMNL layouts, embedding charts, or troubleshooting screen rendering
+- Mentions of TRMNL, TRMNL X, usetrmnl, private plugins, or "merge variables"
 
 ## Skill Structure
 

--- a/trmnl-plugins/SKILL.md
+++ b/trmnl-plugins/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: trmnl-plugins
+description: Build custom private plugins and dashboards for TRMNL e-ink displays (including the TRMNL X). Covers the data layer (webhook push, polling, plugin-merge strategies), the Liquid templating + custom filters used to render data, and the TRMNL Design Framework 3.1 markup (views, mashups, items, tables, charts, typography, responsive/bit-depth utilities). Use when creating or editing a TRMNL private plugin, designing dashboard layouts, writing plugin markup/Liquid, sending data via webhook or polling, embedding charts, or troubleshooting TRMNL screen rendering. Triggers on TRMNL, TRMNL X, usetrmnl, trmnl.com, private plugins, e-ink dashboards, or "merge variables" templates.
+---
+
+# TRMNL Private Plugins & Dashboards
+
+Build custom plugins for TRMNL e-ink displays. A TRMNL plugin = a **data strategy** (how data gets to TRMNL) + **Liquid markup** (how it renders) using the **Design Framework 3.1** CSS.
+
+## Device targets (important)
+
+There is no single screen size. Target the framework's responsive tiers; never hardcode pixels.
+
+| Device | Resolution | Density tier | Breakpoint |
+|--------|-----------|--------------|------------|
+| TRMNL OG | 800×480 | `1bit:` (2 shades) | `md:` |
+| TRMNL OG V2 | 800×480 | `2bit:` (4 shades) | `md:` |
+| TRMNL V2 | 1024×758 | `4bit:` (16 shades) | `lg:` |
+| **TRMNL X** | **1872×1404, 10.3"** | **`4bit:` (16 shades)** | **`lg:`** |
+
+The user has a **TRMNL X**: high-density, 16-level grayscale. Make the responsive base case work everywhere, then use `lg:` / `4bit:` prefixes to exploit the larger grayscale panel. Use real grayscale (`text--gray-50`, dithered images), not just black/white.
+
+## Workflow for building a plugin
+
+1. **Pick a data strategy** — Webhook (push) or Polling (pull). See `references/data-strategies.md`.
+2. **Shape the data** — decide the JSON keys the template reads. Keep merge data flat at the root.
+3. **Write markup for each layout** — plugins have four layout tabs: `full`, `half_horizontal`, `half_vertical`, `quadrant`, plus a **Shared** tab for reusable markup/CSS/JS. Start from `assets/scaffolds/`. At minimum fill `full`.
+4. **Render data with Liquid** — `{{ variable }}`, loops, custom filters. See `references/liquid-filters.md`.
+5. **Style with the framework** — never invent classes. See `references/framework.md`.
+6. **Test** — Force Refresh in the editor; verify overflow/clamping on the target device.
+
+A private plugin is created in the TRMNL web UI: device dropdown → gear → **Developer perks** (one-time upgrade) → **Private Plugin**. Markup is entered per layout tab in the "Edit Markup" editor.
+
+## The single most important markup rule
+
+You write **view-level** markup. TRMNL wraps it in the `<html>` / `<body class="environment trmnl">` / `<div class="screen">` shell and injects `plugins.css` + `plugins.js` automatically. Every layout's markup starts at the `view`:
+
+```html
+<div class="view view--full">
+  <div class="layout">
+    <!-- your content -->
+  </div>
+  <div class="title_bar">
+    <img class="image" src="https://usetrmnl.com/images/plugins/trmnl--render.svg" />
+    <span class="title">My Plugin</span>
+    <span class="instance">{{ trmnl.plugin_settings.instance_name }}</span>
+  </div>
+</div>
+```
+
+Match the view modifier to the layout tab: `view--full`, `view--half_horizontal`, `view--half_vertical`, `view--quadrant`.
+
+## Liquid syntax note
+
+TRMNL uses standard **Liquid** (Shopify): data with `{{ variable }}`, logic with `{% ... %}`. Some TRMNL docs render the braces as `##{{ ... }}` — that `##` is **documentation escaping only**; in the editor use plain `{{ ... }}`. Custom form fields interpolate the same way: `{{ api_key }}`.
+
+## Reference files
+
+Read the one matching the task — don't load all of them up front.
+
+- **`references/data-strategies.md`** — Webhook (URL, `merge_variables`, limits, curl) and Polling (`polling_url`, multiple URLs → `IDX_0`/`IDX_1`, headers/body, verbs), Plugin Merge / data-only mode, form fields, and the `trmnl` global object.
+- **`references/liquid-filters.md`** — All TRMNL custom Liquid filters (`number_to_currency`, `l_date`, `group_by`, `find_by`, `where_exp`, `qr_code`, `append_random`, `parse_json`, …) plus common Shopify filters, with examples.
+- **`references/framework.md`** — Design Framework 3.1 markup: views & mashups, layout/columns/grid/flex, item, table, value/format_value, typography & responsive prefixes, color tokens, image/dithering, progress, rich text, clamp/overflow modulations.
+- **`references/charts-and-recipes.md`** — Embedding Highcharts/Chartkick charts (e-ink-safe config), worked dashboard examples (single metric, multi-column, list/schedule), and a troubleshooting checklist.
+
+## Scaffolds
+
+`assets/scaffolds/` holds copy-paste starter markup. Copy the relevant file into the matching layout tab and replace the placeholders:
+
+- `full.liquid`, `half_horizontal.liquid`, `half_vertical.liquid`, `quadrant.liquid` — empty-but-correct shells for each layout.
+- `schedule-full.liquid` — a worked list/schedule dashboard (loops over events with date/time formatting and overflow handling).
+
+## Hard-won rules
+
+- **Keep merge data flat.** Send `{ "events": [...] }`, not `{ "data": { "events": [...] } }`. Webhook payloads go under `merge_variables`; polling JSON is read from the root (single URL) or `IDX_n` (multiple URLs).
+- **Disable all animation** in charts (`animation: false`) — TRMNL screenshots the page once; animated charts capture half-rendered.
+- **Always handle overflow.** Lists/tables clip silently. Use `data-clamp="N"`, `data-list-limit="true"`, `data-table-limit="true"`, or cap items in Liquid (`limit:`).
+- **Identical merge data skips re-render.** If a screen doesn't update, the data was unchanged — use Force Refresh.
+- **Wrap all client JS** in `document.addEventListener("DOMContentLoaded", function(e){ ... })`.
+- **Respect limits.** Webhook: free 2 KB & 12×/hr, TRMNL+ 5 KB & 30×/hr. Polling refresh intervals: 15 / 60 / 360 / 720 / 1440 min.

--- a/trmnl-plugins/assets/scaffolds/full.liquid
+++ b/trmnl-plugins/assets/scaffolds/full.liquid
@@ -1,0 +1,14 @@
+{# Paste into the `full` layout tab. Fill the layout; keep the title_bar. #}
+<div class="view view--full">
+  <div class="layout">
+    {# --- content goes here --- #}
+    <span class="value value--xlarge value--tnums" data-value-format="true">{{ value }}</span>
+    <span class="label">{{ label | default: 'Label' }}</span>
+  </div>
+
+  <div class="title_bar">
+    <img class="image" src="https://usetrmnl.com/images/plugins/trmnl--render.svg" />
+    <span class="title">{{ plugin_title | default: 'My Plugin' }}</span>
+    <span class="instance">{{ trmnl.plugin_settings.instance_name }}</span>
+  </div>
+</div>

--- a/trmnl-plugins/assets/scaffolds/half_horizontal.liquid
+++ b/trmnl-plugins/assets/scaffolds/half_horizontal.liquid
@@ -1,0 +1,21 @@
+{# Paste into the `half_horizontal` layout tab (top/bottom half — wide & short). #}
+{# Favor a single row of metrics or a short list; keep vertical content minimal. #}
+<div class="view view--half_horizontal">
+  <div class="layout">
+    <div class="grid grid--cols-3 gap--small">
+      {% for m in metrics limit: 3 %}
+        <div class="item">
+          <div class="content">
+            <span class="value value--large value--tnums" data-value-format="true">{{ m.value }}</span>
+            <span class="label" data-clamp="1">{{ m.label }}</span>
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+  </div>
+
+  <div class="title_bar">
+    <img class="image" src="https://usetrmnl.com/images/plugins/trmnl--render.svg" />
+    <span class="title">{{ plugin_title | default: 'My Plugin' }}</span>
+  </div>
+</div>

--- a/trmnl-plugins/assets/scaffolds/half_vertical.liquid
+++ b/trmnl-plugins/assets/scaffolds/half_vertical.liquid
@@ -1,0 +1,21 @@
+{# Paste into the `half_vertical` layout tab (left/right half — narrow & tall). #}
+{# Favor a vertical list; clamp titles so they don't wrap past the narrow width. #}
+<div class="view view--half_vertical">
+  <div class="layout">
+    <div class="flex flex--col gap--small" data-list-limit="true">
+      {% for item in items limit: 6 %}
+        <div class="item">
+          <div class="content">
+            <span class="title title--small" data-clamp="1">{{ item.title }}</span>
+            <span class="label label--small" data-clamp="1">{{ item.subtitle }}</span>
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+  </div>
+
+  <div class="title_bar">
+    <img class="image" src="https://usetrmnl.com/images/plugins/trmnl--render.svg" />
+    <span class="title">{{ plugin_title | default: 'My Plugin' }}</span>
+  </div>
+</div>

--- a/trmnl-plugins/assets/scaffolds/quadrant.liquid
+++ b/trmnl-plugins/assets/scaffolds/quadrant.liquid
@@ -1,0 +1,13 @@
+{# Paste into the `quadrant` layout tab (one quarter — very small). #}
+{# Show ONE headline metric or a 1-2 line summary. Anything more will clip. #}
+<div class="view view--quadrant">
+  <div class="layout layout--col">
+    <span class="value value--large value--tnums" data-value-format="true" data-fit-value="true">{{ value }}</span>
+    <span class="label" data-clamp="1">{{ label | default: 'Label' }}</span>
+  </div>
+
+  <div class="title_bar">
+    <img class="image" src="https://usetrmnl.com/images/plugins/trmnl--render.svg" />
+    <span class="title">{{ plugin_title | default: 'My Plugin' }}</span>
+  </div>
+</div>

--- a/trmnl-plugins/assets/scaffolds/schedule-full.liquid
+++ b/trmnl-plugins/assets/scaffolds/schedule-full.liquid
@@ -1,0 +1,47 @@
+{# Worked list/schedule dashboard for the `full` layout. #}
+{# Expects a flat `events` array, e.g. via webhook merge_variables:           #}
+{#   { "merge_variables": { "events": [                                       #}
+{#       { "title": "...", "date": "2026-08-01", "time": "09:00",             #}
+{#         "location": "...", "allDay": false } ] } }                         #}
+{# Reads at the root (webhook or single polling URL). Dates are ISO strings.  #}
+<div class="view view--full">
+  <div class="layout">
+    {% if events == empty or events == nil %}
+      <div class="richtext richtext--center">
+        <div class="content content--center text--center"><p>No upcoming events</p></div>
+      </div>
+    {% else %}
+      <div class="flex flex--col gap--small" data-list-limit="true">
+        {% for e in events limit: 8 %}
+          <div class="item">
+            <div class="meta">
+              <span class="index">{{ e.date | l_date: '%-d', trmnl.user.locale }}</span>
+            </div>
+            <div class="content">
+              <span class="title title--small" data-clamp="1">{{ e.title }}</span>
+              <div class="flex gap--small">
+                <span class="label label--small label--underline">
+                  {{ e.date | l_date: '%a %b %-d', trmnl.user.locale }}
+                </span>
+                {% if e.allDay %}
+                  <span class="label label--small label--underline">All day</span>
+                {% elsif e.time and e.time != "" %}
+                  <span class="label label--small label--underline">{{ e.time }}</span>
+                {% endif %}
+                {% if e.location and e.location != "" %}
+                  <span class="label label--small" data-clamp="1">{{ e.location }}</span>
+                {% endif %}
+              </div>
+            </div>
+          </div>
+        {% endfor %}
+      </div>
+    {% endif %}
+  </div>
+
+  <div class="title_bar">
+    <img class="image" src="https://usetrmnl.com/images/plugins/trmnl--render.svg" />
+    <span class="title">{{ schedule_title | default: 'Schedule' }}</span>
+    <span class="instance">{{ trmnl.plugin_settings.instance_name }}</span>
+  </div>
+</div>

--- a/trmnl-plugins/references/charts-and-recipes.md
+++ b/trmnl-plugins/references/charts-and-recipes.md
@@ -1,0 +1,205 @@
+# Charts & Dashboard Recipes
+
+## Contents
+- [Charts (Highcharts / Chartkick)](#charts-highcharts--chartkick)
+- [Recipe: single big metric](#recipe-single-big-metric)
+- [Recipe: multi-metric grid](#recipe-multi-metric-grid)
+- [Recipe: list / schedule](#recipe-list--schedule)
+- [Recipe: mashup of two views](#recipe-mashup-of-two-views)
+- [Troubleshooting checklist](#troubleshooting-checklist)
+
+---
+
+## Charts (Highcharts / Chartkick)
+
+TRMNL hosts the libraries. Put `<script>` includes and the init code in the **Shared** tab (or inline in the layout). Charts render once into a screenshot, so **animation must be off**.
+
+**CDN includes:**
+```html
+<script src="https://trmnl.com/js/highcharts/12.3.0/highcharts.js"></script>
+<script src="https://trmnl.com/js/chartkick/5.0.1/chartkick.min.js"></script>
+```
+
+**Container** — give it a unique id (`append_random`) and let it fill the layout:
+```html
+<div class="view view--full">
+  <div class="layout layout--col gap--space-between">
+    <div class="grid grid--cols-3 gap--small">
+      <!-- summary metrics here -->
+    </div>
+    {% assign chart_id = 'chart-' | append_random %}
+    <div id="{{ chart_id }}" class="w--full"></div>
+  </div>
+  <div class="title_bar"> ... </div>
+</div>
+```
+
+**Init (e-ink-safe Highcharts):**
+```html
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  Highcharts.chart("{{ chart_id }}", {
+    chart:    { animation: false, backgroundColor: 'transparent', height: null, style: { fontFamily: 'inherit' } },
+    title:    { text: null },
+    credits:  { enabled: false },
+    legend:   { enabled: false },
+    colors:   ["black"],
+    xAxis: {
+      categories: {{ labels | json }},
+      lineColor: 'black', tickColor: 'black',
+      labels: { style: { fontSize: '16px', color: 'black' } }
+    },
+    yAxis: {
+      title: { text: null },
+      gridLineDashStyle: 'Dot', gridLineColor: 'black',
+      labels: { style: { fontSize: '16px', color: 'black' } }
+    },
+    plotOptions: { series: { animation: false, marker: { enabled: false } } },
+    series: [{ data: {{ values | json }} }]
+  });
+});
+</script>
+```
+
+E-ink rules:
+- `animation: false` at **both** `chart` and `plotOptions.series` levels — otherwise the screenshot catches a half-drawn chart.
+- `backgroundColor: 'transparent'`, `colors: ["black"]`, dashed/dotted grid lines (`gridLineDashStyle: 'Dot'`).
+- `height: null` expands to fill; fonts ~16px+ to stay legible.
+- On TRMNL X (16-shade) you may add a few gray series colors (e.g. `["black", "#555555", "#999999"]`) — guard with `4bit:` styling where needed.
+- Pass Liquid data into JS with `| json` so it becomes valid JSON literals.
+
+Chartkick alternative (simpler):
+```html
+<div id="{{ chart_id }}" style="height:300px;"></div>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  new Chartkick.LineChart("{{ chart_id }}", {{ series | json }}, {
+    animation: false, colors: ["black"], legend: false, points: false
+  });
+});
+</script>
+```
+
+---
+
+## Recipe: single big metric
+
+```html
+<div class="view view--full">
+  <div class="layout layout--col gap--space-between">
+    <div class="item">
+      <div class="content">
+        <span class="value value--xlarge value--tnums" data-value-format="true" data-fit-value="true">{{ amount }}</span>
+        <span class="label">{{ metric_label }}</span>
+      </div>
+    </div>
+    <div class="progress-bar">
+      <div class="content">
+        <span class="label">Goal</span>
+        <span class="value value--xxsmall">{{ pct }}%</span>
+      </div>
+      <div class="track"><div class="fill" style="width: {{ pct }}%"></div></div>
+    </div>
+  </div>
+  <div class="title_bar">
+    <img class="image" src="https://usetrmnl.com/images/plugins/trmnl--render.svg" />
+    <span class="title">{{ plugin_title | default: 'Metric' }}</span>
+    <span class="instance">{{ trmnl.plugin_settings.instance_name }}</span>
+  </div>
+</div>
+```
+
+## Recipe: multi-metric grid
+
+```html
+<div class="view view--full">
+  <div class="layout">
+    <div class="grid grid--cols-3 gap--small">
+      {% for m in metrics limit: 6 %}
+        <div class="item">
+          <div class="content">
+            <span class="value value--large value--tnums" data-value-format="true">{{ m.value }}</span>
+            <span class="label" data-clamp="1">{{ m.label }}</span>
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+  </div>
+  <div class="title_bar">
+    <img class="image" src="https://usetrmnl.com/images/plugins/trmnl--render.svg" />
+    <span class="title">Dashboard</span>
+  </div>
+</div>
+```
+
+## Recipe: list / schedule
+
+Loops events, formats dates with `l_date`, limits + clamps to avoid clipping. See also `assets/scaffolds/schedule-full.liquid`.
+
+```html
+<div class="view view--full">
+  <div class="layout">
+    {% if events == empty or events == nil %}
+      <div class="richtext richtext--center">
+        <div class="content content--center text--center"><p>No upcoming events</p></div>
+      </div>
+    {% else %}
+      <div class="flex flex--col gap--small" data-list-limit="true">
+        {% for e in events limit: 8 %}
+          <div class="item">
+            <div class="meta"><span class="index">{{ e.date | l_date: '%-d', trmnl.user.locale }}</span></div>
+            <div class="content">
+              <span class="title title--small" data-clamp="1">{{ e.title }}</span>
+              <div class="flex gap--small">
+                <span class="label label--small label--underline">{{ e.date | l_date: '%a %b %-d', trmnl.user.locale }}</span>
+                {% if e.time != "" and e.time %}
+                  <span class="label label--small label--underline">{{ e.time }}</span>
+                {% endif %}
+                {% if e.location != "" and e.location %}
+                  <span class="label label--small" data-clamp="1">{{ e.location }}</span>
+                {% endif %}
+              </div>
+            </div>
+          </div>
+        {% endfor %}
+      </div>
+    {% endif %}
+  </div>
+  <div class="title_bar">
+    <img class="image" src="https://usetrmnl.com/images/plugins/trmnl--render.svg" />
+    <span class="title">{{ schedule_title | default: 'Schedule' }}</span>
+    <span class="instance">{{ trmnl.plugin_settings.instance_name }}</span>
+  </div>
+</div>
+```
+
+## Recipe: mashup of two views
+
+```html
+<div class="mashup mashup--1Lx1R">
+  <div class="view view--half_vertical">
+    <div class="layout"> <!-- left content --> </div>
+    <div class="title_bar"><span class="title">Left</span></div>
+  </div>
+  <div class="view view--half_vertical">
+    <div class="layout"> <!-- right content --> </div>
+    <div class="title_bar"><span class="title">Right</span></div>
+  </div>
+</div>
+```
+
+---
+
+## Troubleshooting checklist
+
+| Symptom | Likely cause / fix |
+|---------|--------------------|
+| Screen didn't update | Merge data unchanged (TRMNL skips identical renders) → **Force Refresh**; or webhook hit the `429` rate limit. |
+| Chart half-drawn / blank | Animation still on → set `animation: false` at chart **and** series level; ensure JS is in `DOMContentLoaded`. |
+| Content cut off | Add `data-clamp`, `data-list-limit`, `data-table-limit`, or `limit:` in the loop. |
+| Variable renders empty | Wrong nesting — read root keys (single URL / webhook `merge_variables`) or `IDX_n` (multiple URLs); don't double-nest under `data`. |
+| Data won't parse | JSON-in-a-string field → `| parse_json` first. |
+| Looks black-and-white only | Use `gray-*` tokens + `image-dither`; TRMNL X supports 16 shades (`4bit:`). |
+| Layout fine on OG, broken on X | Hardcoded px → use `cqw`/`cqh`, `w--full`, and `lg:`/`4bit:` responsive prefixes. |
+| Two charts collide | Reuse of element `id` → generate ids with `| append_random`. |
+| Title bar instance blank | `{{ trmnl.plugin_settings.instance_name }}` only set once the instance is named. |

--- a/trmnl-plugins/references/data-strategies.md
+++ b/trmnl-plugins/references/data-strategies.md
@@ -1,0 +1,138 @@
+# TRMNL Data Strategies
+
+How data reaches a private plugin and becomes merge variables in the template. Choose one strategy per plugin.
+
+## Contents
+- [Webhook (push)](#webhook-push)
+- [Polling (pull)](#polling-pull)
+- [Plugin Merge / data-only](#plugin-merge--data-only)
+- [Form fields (custom settings)](#form-fields-custom-settings)
+- [The `trmnl` global object](#the-trmnl-global-object)
+- [Reading data in the template](#reading-data-in-the-template)
+
+---
+
+## Webhook (push)
+
+You POST JSON to TRMNL. No server required — drive it from a cron job, Apple Shortcut, Google Apps Script, Cloudflare Worker, GitHub Action, etc.
+
+**Endpoint** (the plugin's Webhook URL, shown in the plugin's settings form):
+```
+POST https://usetrmnl.com/api/custom_plugins/{PLUGIN_SETTINGS_UUID}
+```
+(Older docs use `trmnl.com`; both resolve. The UUID is the plugin instance's Plugin Settings UUID.)
+
+**Body** — data MUST be wrapped in `merge_variables`, kept flat:
+```json
+{ "merge_variables": { "text": "You can do it!", "author": "Rob Schneider" } }
+```
+
+**Full example:**
+```bash
+curl "https://usetrmnl.com/api/custom_plugins/asdfqwerty1234" \
+  -H "Content-Type: application/json" \
+  -X POST \
+  -d '{"merge_variables": {"text":"You can do it!", "author": "Rob Schneider"}}'
+```
+
+In the template these are read at the root: `{{ text }}`, `{{ author }}`.
+
+**Read back current data:** `GET` the same URL.
+
+**Limits:**
+| | Free | TRMNL+ |
+|---|---|---|
+| Payload size | 2 KB | 5 KB |
+| Requests/hour | 12 | 30 |
+
+Exceeding the rate returns HTTP `429`. To send more than 2/5 KB, switch to Polling. Each POST **replaces** the stored merge variables (it is not append/merge), so send the complete payload each time.
+
+---
+
+## Polling (pull)
+
+TRMNL fetches URL(s) you control on an interval. Best when you already have an API/feed, or need larger payloads than webhook allows.
+
+**Configuration fields:**
+- **Polling URL(s)** — one or more URLs, line-break separated. Each may return JSON, RSS, XML, plaintext, or CSV.
+- **Polling Verb** — `GET` (default) or `POST`.
+- **Polling Headers** — ampersand-joined `key=value` pairs:
+  ```
+  authorization=bearer xxx&content-type=application/json
+  ```
+- **Polling Body** — JSON object (for POST). Interpolate form fields with `{{ form_field_keyname }}`.
+- **Refresh interval** — 15, 60, 360, 720, or 1440 minutes.
+
+**Accessing the response:**
+- **Single URL** → response is read directly at the root: `{{ field_name }}`, `{{ items[0].name }}`.
+- **Multiple URLs** → each response is namespaced by index: `{{ IDX_0.field_name }}`, `{{ IDX_1.field_name }}` (in URL order).
+
+Interpolate form-field values into the URL/headers/body for secrets and per-instance config:
+```
+https://api.example.com/v1/data?key={{ api_key }}
+```
+
+---
+
+## Plugin Merge / data-only
+
+Use the **Plugin Merge** strategy to combine/transform data already produced by other plugin instances, or to use a plugin purely as a data source (data-only mode).
+
+- All connected plugin data becomes available in the template under the **"Your Variables"** dropdown.
+- For data-only: connect a plugin instance to your Playlist and hide it (eyeball icon). Parsed data appears under a `<plugin_keyname>_<plugin_setting_id>` node in the Merge Variables dropdown.
+- Preview parsed data at `https://usetrmnl.com/plugins/demo?data=true&plugin_setting_id=<id>`.
+
+---
+
+## Form fields (custom settings)
+
+Define GUI inputs on the plugin so each instance can be configured without editing markup. Field types include text, number, select, etc. Each has a **keyname**.
+
+Reference a field anywhere — markup, polling URL, headers, or body — by keyname:
+```
+{{ api_key }}        {{ city }}        {{ units }}
+```
+
+Use form fields for API keys, locations, thresholds, display toggles — anything that varies per instance.
+
+---
+
+## The `trmnl` global object
+
+Always available in templates regardless of strategy. Common paths:
+
+| Path | Value |
+|------|-------|
+| `trmnl.user.first_name` | User's first name |
+| `trmnl.user.name` | Full name |
+| `trmnl.user.locale` | Locale (e.g. `en`) |
+| `trmnl.user.time_zone` / `trmnl.user.utc_offset` | Timezone info |
+| `trmnl.plugin_settings.instance_name` | This instance's name (good for the `title_bar` `instance` span) |
+| `trmnl.plugin_settings.custom_fields_values.<keyname>` | A form field value (alternative to bare `{{ keyname }}`) |
+
+Use these to localize dates (`l_date` with `trmnl.user.locale`) and label the title bar.
+
+---
+
+## Reading data in the template
+
+```liquid
+{# webhook or single polling URL: root access #}
+<span class="value">{{ temperature }}</span>
+
+{# loop a collection #}
+{% for event in events limit: 6 %}
+  <div class="item">{{ event.title }} — {{ event.date | l_date: '%b %-d' }}</div>
+{% endfor %}
+
+{# multiple polling URLs #}
+<span>{{ IDX_0.weather.temp }}</span>
+<span>{{ IDX_1.headlines[0].title }}</span>
+
+{# guard for missing data #}
+{% if events == empty or events == nil %}
+  <span class="label">No upcoming events</span>
+{% endif %}
+```
+
+Tip: a string of JSON inside a field can be turned into an object with `| parse_json` (see `liquid-filters.md`).

--- a/trmnl-plugins/references/framework.md
+++ b/trmnl-plugins/references/framework.md
@@ -1,0 +1,276 @@
+# TRMNL Design Framework 3.1 — Markup Reference
+
+Use these classes; do not invent class names. The framework's `plugins.css`/`plugins.js` are auto-injected by TRMNL. Canonical docs: https://trmnl.com/framework/docs/3.1
+
+## Contents
+- [Structural scaffold](#structural-scaffold)
+- [Views & layout tabs](#views--layout-tabs)
+- [Mashups](#mashups)
+- [Layout, columns, grid, flex](#layout-columns-grid-flex)
+- [Title bar](#title-bar)
+- [Item](#item)
+- [Value & Format Value](#value--format-value)
+- [Table](#table)
+- [Progress](#progress)
+- [Rich text](#rich-text)
+- [Typography](#typography)
+- [Color tokens](#color-tokens)
+- [Images & dithering](#images--dithering)
+- [Spacing & sizing utilities](#spacing--sizing-utilities)
+- [Responsive & bit-depth prefixes](#responsive--bit-depth-prefixes)
+- [Overflow / clamp modulations](#overflow--clamp-modulations)
+
+---
+
+## Structural scaffold
+
+Fixed hierarchy: **Screen → View → Layout → (content) → Title Bar**. You write from the `view` down (TRMNL provides `screen`):
+
+```html
+<div class="view view--full">
+  <div class="layout">
+    <!-- content -->
+  </div>
+  <div class="title_bar">
+    <img class="image" src="https://usetrmnl.com/images/plugins/trmnl--render.svg" />
+    <span class="title">Plugin Title</span>
+    <span class="instance">{{ trmnl.plugin_settings.instance_name }}</span>
+  </div>
+</div>
+```
+
+## Views & layout tabs
+
+One view modifier per layout tab:
+
+| Tab | View class | Approx. footprint |
+|-----|-----------|-------------------|
+| full | `view--full` | whole screen |
+| half_horizontal | `view--half_horizontal` | top or bottom half |
+| half_vertical | `view--half_vertical` | left or right half |
+| quadrant | `view--quadrant` | one quarter |
+
+## Mashups
+
+A mashup arranges multiple views on one screen. The mashup modifier sets the arrangement; each child view's own modifier sets its footprint.
+
+```html
+<div class="mashup mashup--1Lx1R">
+  <div class="view view--half_vertical"> ... </div>
+  <div class="view view--half_vertical"> ... </div>
+</div>
+```
+
+Modifiers: `mashup--1Lx1R` (1 left, 1 right), `mashup--1Tx1B` (top/bottom), `mashup--1Lx2R`, `mashup--2Lx1R`, `mashup--2Tx1B`, `mashup--1Tx2B`, `mashup--2x2`.
+
+## Layout, columns, grid, flex
+
+**Layout** is the primary content container inside a view:
+```html
+<div class="layout layout--col gap--space-between"> ... </div>
+```
+- `layout--col` stacks children vertically; combine with `gap--*` (e.g. `gap--space-between`).
+
+**Columns** (legacy column system):
+```html
+<div class="columns"><div class="column"> ... </div><div class="column"> ... </div></div>
+```
+
+**Grid** (preferred for tiled metrics):
+- `grid` + `grid--cols-{1..N}` — fixed column count.
+- `grid--wrap` — responsive wrapping; `grid--min-{n}` sets a minimum track size (`grid--min-32`, `grid--min-56`).
+- Cells: `col` (vertical), `col--span-{n}`, alignment `col--start|col--center|col--end`; `row` with `row--start|row--center|row--end`.
+
+```html
+<div class="grid grid--cols-3 gap--small">
+  <div class="item"> ... </div>
+  <div class="item"> ... </div>
+  <div class="item"> ... </div>
+</div>
+```
+
+**Flex:** `flex` with `gap--*`; combine with the spacing/alignment utilities below.
+
+## Title bar
+
+```html
+<div class="title_bar">
+  <img class="image" src="/images/plugins/trmnl--render.svg">
+  <span class="title">Calendar</span>
+  <span class="instance">Production</span>   <!-- optional instance label -->
+</div>
+```
+Classes: `title_bar`, `image`, `title`, `instance`.
+
+## Item
+
+A list row with optional meta (index/icon), title, description, and labels.
+
+```html
+<div class="item">
+  <div class="meta"><span class="index">1</span></div>   <!-- meta optional; index optional -->
+  <div class="content">
+    <span class="title title--small">Team Meeting</span>
+    <span class="description">Weekly team sync-up</span>
+    <div class="flex gap--small">
+      <span class="label label--small label--underline">9:00 AM – 10:00 AM</span>
+      <span class="label label--small label--underline">Confirmed</span>
+    </div>
+  </div>
+</div>
+```
+
+With an icon instead of an index:
+```html
+<div class="item">
+  <div class="meta"></div>
+  <div class="icon"><img src="icon.svg" class="w--[6cqw] h--[6cqw]" /></div>
+  <div class="content">
+    <span class="value value--small">72°</span>
+    <span class="label">Temperature</span>
+  </div>
+</div>
+```
+
+Classes: `item`, `meta`, `content`, `icon`, `index`; children `title`/`title--small`, `description`, `label`/`label--small`/`label--underline`, `value`/`value--small`. Emphasis modifiers: `item--emphasis-1|2|3`.
+
+## Value & Format Value
+
+Big numbers. Add `data-value-format="true"` to auto-format, `value--tnums` for tabular (aligned) digits.
+
+```html
+<span class="value value--xlarge value--tnums" data-value-format="true">2345678</span>
+<span class="value value--large  value--tnums" data-value-format="true" data-fit-value="true">$456789</span>
+<span class="value value--small  value--tnums" data-value-format="true" data-value-locale="de-DE">€123456.78</span>
+```
+- Sizes: `value--small`, (default), `value--large`, `value--xlarge` (plus `value--xxsmall`/`value--xsmall` for captions).
+- Attributes: `data-value-format="true"`, `data-fit-value="true"` (shrink to fit width), `data-value-locale="en-US|de-DE|fr-FR|en-GB|ja-JP"`.
+- Pair with a `label` for a captioned metric.
+
+## Table
+
+```html
+<table class="table" data-table-limit="true">
+  <thead>
+    <tr><th><span class="title title--small">Header</span></th></tr>
+  </thead>
+  <tbody>
+    <tr><td><span class="label">Cell</span></td></tr>
+  </tbody>
+</table>
+```
+- Base: `table`; index column: `table--indexed` (cells use `meta` + `index`).
+- Size modifiers: `table--xsmall`, `table--small` (alias `table--condensed`), `table--base`, `table--large`, `table--xlarge`.
+- Headers use `title`/`title--small`; cells use `label`/`label--small`.
+- `data-table-limit="true"` enables overflow handling; `data-clamp="1"` truncates a cell to one line.
+
+## Progress
+
+Bar:
+```html
+<div class="progress-bar">
+  <div class="content">
+    <span class="label">Regular Progress</span>
+    <span class="value value--xxsmall">50%</span>
+  </div>
+  <div class="track"><div class="fill" style="width: 50%"></div></div>
+</div>
+```
+Dots:
+```html
+<div class="progress-dots">
+  <div class="track">
+    <div class="dot dot--filled"></div>
+    <div class="dot dot--filled"></div>
+    <div class="dot dot--current"></div>
+    <div class="dot"></div>
+  </div>
+</div>
+```
+Sizes: `progress-bar--xsmall|small|base|large`, `progress-dots--xsmall|small|base|large`. Emphasis: `progress-bar--emphasis-2|3`. Parts: bar = `content`/`track`/`fill`; dots = `track`/`dot`/`dot--filled`/`dot--current`.
+
+## Rich text
+
+Center/align prose and markdown blocks:
+```html
+<div class="richtext richtext--center gap--large">
+  <img class="image" src="/assets/trmnl--glyph-black-large.svg">
+  <div class="content content--center gap text--center">
+    <p>Center-aligned rich text content.</p>
+  </div>
+</div>
+```
+- Container align: `richtext--left|center|right`.
+- Content size: `content--small|base|large|xlarge|xxlarge|xxxlarge`; align `content--left|center|right`.
+- Auto-fit: `data-content-limiter="true"` (+ optional `data-content-max-height="140"`), `data-pixel-perfect="true"`.
+
+## Typography
+
+`text--{size}` sets font family, size, line-height, and smoothing per density tier:
+
+| Class | Size / line-height |
+|-------|--------------------|
+| `text--small` | 12 / 1 |
+| `text--base` | 16 / 1.25 |
+| `text--large` | 21 / 1 |
+| `text--xlarge` | 26 / 29 |
+| `text--xxlarge` | 38 / 42 |
+| `text--xxxlarge` | 58 / 70 |
+| `text--mega` | 74 / 86 |
+| `text--giga` | 96 / 108 |
+| `text--tera` | 128 / 128 |
+| `text--peta` | 170 / 180 |
+
+Also: weight `font--bold`; alignment `text--left|center|right`; color via `text--{token}` (see below). On the high-density TRMNL X these use Inter Variable; on low-density panels a pixel font.
+
+## Color tokens
+
+CSS-variable tokens (use the utility classes, not raw vars):
+- **Grayscale:** `--black`, `--gray-10` … `--gray-75`, `--white`. Classes: `text--gray-50`, `bg--gray-20`, etc.
+- **Chromatic:** red, orange, yellow, lime, green, cyan, blue, violet, purple, pink — each with lightness steps 10–75 (e.g. `text--blue-60`, `bg--red-40`).
+- **Semantic:** `--color-primary` (blue), `--color-success` (green), `--color-error` (red), `--color-warning` (orange) → `text--primary`, `bg--success`, etc.
+- Backgrounds: `bg--{token}`; text color: `text--{token}` incl. `text--white` / `text--black`.
+
+Note: TRMNL dark mode inverts the whole screen except images, so the palette can look inverted. On TRMNL X (16-shade) you have real grays — use `gray-*` for hierarchy instead of only black/white. (Legacy `gray-1`…`gray-7` map to `gray-10`…`gray-70`.)
+
+## Images & dithering
+
+```html
+<img class="image image-dither rounded" src="path.png">
+```
+- `image` base; `image-dither` simulates grayscale via dither patterns (essential on 1-bit, still helps on grayscale); `rounded` optional.
+- Object-fit: `image--fill`, `image--contain`, `image--cover`.
+
+## Spacing & sizing utilities
+
+- Gap: `gap`, `gap--small`, `gap--large`, `gap--space-between`.
+- Arbitrary sizing (container-query units recommended): `w--[240px]`, `w--[6cqw]`, `h--[6cqw]`, `w--full`. `cqw`/`cqh` (% of container) scale across devices better than fixed px.
+
+## Responsive & bit-depth prefixes
+
+Mobile-first. Prefix order: **`size:orientation:bit-depth:utility`**.
+
+| Kind | Prefixes | Activates |
+|------|----------|-----------|
+| Size | `sm:` / `md:` / `lg:` | ≥600px (Kindle) / ≥800px (TRMNL OG) / ≥1024px (TRMNL V2, **TRMNL X**) |
+| Orientation | `portrait:` | portrait only (landscape is default, no prefix) |
+| Bit-depth | `1bit:` / `2bit:` / `4bit:` | 2 / 4 / **16 (TRMNL X)** shades — NOT progressive, each targets one depth only |
+
+```html
+<span class="value value--large lg:value--xlarge 4bit:text--gray-60">42</span>
+<div class="gap--small md:portrait:gap--large"> ... </div>
+```
+
+For TRMNL X, lean on `lg:` (bigger type/denser grids) and `4bit:` (grayscale depth).
+
+## Overflow / clamp modulations
+
+E-ink silently clips overflow — always constrain content.
+
+- **`data-clamp="N"`** — clamp any text to N lines (engine re-applies on layout change). Responsive variants: `data-clamp-sm`, `data-clamp-md`, `data-clamp-lg`, `data-clamp-portrait`, `data-clamp-md-portrait`. (Legacy classes `clamp--1`…`clamp--50`, `clamp--none`.)
+- **`data-list-limit="true"`** — auto-limit list items to what fits.
+- **`data-table-limit="true"`** — auto-limit table rows to what fits.
+- **`data-content-limiter="true"`** (+ `data-content-max-height`) — shrink rich text to fit.
+- **`data-pixel-perfect="true"`** — snap text to the pixel grid for crisp e-ink rendering.
+
+Also cap in Liquid as a backstop: `{% for x in items limit: 8 %}`.

--- a/trmnl-plugins/references/liquid-filters.md
+++ b/trmnl-plugins/references/liquid-filters.md
@@ -1,0 +1,116 @@
+# Liquid Filters for TRMNL
+
+TRMNL templates use standard **Liquid** (Shopify) plus TRMNL-specific custom filters. Syntax: `{{ value | filter: arg }}`. Logic uses `{% if %}`, `{% for %}`, `{% assign %}`, `{% capture %}`.
+
+## Contents
+- [TRMNL custom filters](#trmnl-custom-filters)
+- [Commonly used standard Liquid filters](#commonly-used-standard-liquid-filters)
+- [Date/time formatting (strftime)](#datetime-formatting-strftime)
+- [Patterns](#patterns)
+
+---
+
+## TRMNL custom filters
+
+### Data
+| Filter | Purpose | Example → Output |
+|--------|---------|------------------|
+| `json` | Serialize a variable to JSON | `{{ my_var \| json }}` → `{"foo":"bar"}` |
+| `parse_json` | Parse a JSON string into an object | `{% assign parsed = data.stuff \| parse_json %}` then `{{ parsed.num }}` → `5` |
+
+### Collections
+| Filter | Purpose | Example → Output |
+|--------|---------|------------------|
+| `group_by` | Group array of objects by a key | `{{ people \| group_by: "age" }}` → `{35 => [...], 29 => [...]}` |
+| `find_by` | Find first item by key/value (optional fallback arg) | `{{ people \| find_by: "name", "Ryan" }}` → `{"age"=>35,"name"=>"Ryan"}` |
+| `where_exp` | Filter array by an expression | `{{ numbers \| where_exp: "n", "n >= 3" }}` → `[3,4,5]` |
+| `sample` | Random element | `{{ isbns \| split: ',' \| sample }}` |
+
+### Numbers
+| Filter | Purpose | Example → Output |
+|--------|---------|------------------|
+| `number_with_delimiter` | Thousands separators | `{{ 1234 \| number_with_delimiter }}` → `1,234` |
+| `number_to_currency` | Currency formatting | `{{ 10420 \| number_to_currency }}` → `$10,420.00` |
+
+### Strings / markup
+| Filter | Purpose | Example → Output |
+|--------|---------|------------------|
+| `pluralize` | Pluralize a word for a count | `{{ "book" \| pluralize: 2 }}` → `2 books` |
+| `markdown_to_html` | Render markdown to HTML | `{{ markdown \| markdown_to_html }}` |
+
+### Dates
+| Filter | Purpose | Example → Output |
+|--------|---------|------------------|
+| `days_ago` | Date N days before today | `{{ 7 \| days_ago }}` → `yyyy-mm-dd` |
+| `ordinalize` | strftime with ordinal day | `{{ "2025-10-02" \| ordinalize: "%A, %B <<ordinal_day>>, %Y" }}` → `Thursday, October 2nd, 2025` |
+| `l_date` | Localize a date (object or string) | `{{ '2025-01-11' \| l_date: '%y %b', 'ko' }}` → `25 1월` |
+| `l_word` | Translate a common word | `{{ "today" \| l_word: 'es-ES' }}` → `hoy` |
+
+### Utility
+| Filter | Purpose | Example → Output |
+|--------|---------|------------------|
+| `append_random` | Append a random suffix (unique element IDs) | `{% assign id = "chart-" \| append_random %}` → `chart-q7x1` |
+| `qr_code` | String/URL → scannable QR image (size arg) | `{{ "https://trmnl.ink" \| qr_code: 3 }}` |
+
+> Use `append_random` for any element a script targets (chart containers especially) so multiple instances / mashups don't collide on the same `id`.
+
+---
+
+## Commonly used standard Liquid filters
+
+`upcase` `downcase` `capitalize` `truncate: 15` `truncatewords: 8` `strip` `strip_html`
+`split: ','` `join: ', '` `first` `last` `size` `reverse` `sort` `uniq` `map: 'key'`
+`where: 'key', value` `slice: 0, 3` `replace: 'a','b'` `default: 'N/A'`
+`plus:` `minus:` `times:` `divided_by:` `modulo:` `round:` `ceil` `floor` `abs`
+`date: '%b %-d'` `escape` `url_encode`
+
+```liquid
+{{ title | truncate: 24 }}
+{{ events | map: 'title' | join: ', ' }}
+{{ price | default: 0 | number_to_currency }}
+{{ events | where: 'status', 'confirmed' | size }}
+```
+
+---
+
+## Date/time formatting (strftime)
+
+`l_date`, `ordinalize`, and standard `date` use Ruby strftime tokens:
+
+| Token | Meaning | Example |
+|-------|---------|---------|
+| `%Y` `%y` | Year (4 / 2 digit) | 2026 / 26 |
+| `%B` `%b` | Month name / abbrev | August / Aug |
+| `%m` | Month (zero-padded) | 08 |
+| `%A` `%a` | Weekday / abbrev | Saturday / Sat |
+| `%d` `%-d` | Day (padded / no pad) | 01 / 1 |
+| `%H:%M` | 24h time | 17:00 |
+| `%-I:%M %p` | 12h time | 5:00 PM |
+| `%Z` `%z` | TZ name / offset | CDT / -0500 |
+
+`ordinalize` adds `<<ordinal_day>>` for "1st / 2nd / 3rd". Pass a locale to `l_date` as the 2nd arg, or use `trmnl.user.locale`.
+
+---
+
+## Patterns
+
+```liquid
+{# Localize to the user's settings #}
+{{ event.date | l_date: '%a %b %-d', trmnl.user.locale }}
+
+{# Parse a JSON string field, then read it #}
+{% assign cfg = settings_json | parse_json %}
+{{ cfg.threshold }}
+
+{# Find one record, with fallback #}
+{% assign me = people | find_by: 'id', user_id %}
+{{ me.name | default: 'Unknown' }}
+
+{# Filter + count #}
+{% assign open = tickets | where_exp: 't', 't.status != "closed"' %}
+{{ open | size }} {{ "ticket" | pluralize: open.size }}
+
+{# Unique chart id (avoid collisions in mashups) #}
+{% assign chart_id = 'chart-' | append_random %}
+<div id="{{ chart_id }}"></div>
+```


### PR DESCRIPTION
## Summary

Adds a new **`trmnl-plugins`** skill for building custom private plugins and dashboards for TRMNL e-ink displays, including the **TRMNL X** (10.3", 1872×1404, 16-level grayscale).

The skill is structured for progressive disclosure — a lean `SKILL.md` workflow plus four reference files and copy-paste layout scaffolds:

- **`SKILL.md`** — build workflow, device/density targets, the view-level markup rule, and hard-won rules.
- **`references/data-strategies.md`** — webhook (push), polling (pull), plugin-merge/data-only, form fields, and the `trmnl` global object.
- **`references/liquid-filters.md`** — TRMNL's custom Liquid filters + common Shopify filters + strftime.
- **`references/framework.md`** — Design Framework 3.1 markup: views, mashups, items, tables, value/format_value, typography, color tokens, images/dithering, progress, rich text, responsive/bit-depth prefixes, and overflow/clamp modulations.
- **`references/charts-and-recipes.md`** — e-ink-safe Highcharts/Chartkick config, dashboard recipes, and a troubleshooting checklist.
- **`assets/scaffolds/`** — starter markup for `full`, `half_horizontal`, `half_vertical`, `quadrant`, plus a worked `schedule-full.liquid`.

Class names, filters, and the webhook API were sourced verbatim from the live TRMNL framework component pages and help docs.

## Notes / not-yet-verified on a live instance
- **`{{ }}` vs `##{{ }}`** — TRMNL docs render Liquid braces as `##{{ }}`; treated the `##` as documentation escaping and used plain `{{ }}` (standard Liquid).
- **Webhook host** — used `usetrmnl.com/api/custom_plugins/{UUID}` (docs also show `trmnl.com`; both resolve).

## Validation
Packaged/validated clean via skill-creator's `package_skill.py` (✅ Skill is valid). README updated with table row + detail section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)