### PR TITLE
Add amplify-lambda-node24-upgrade skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ npx skills add asebesta/claude-skills/<skill-name>
 
 | Skill | Description |
 |-------|-------------|
+| [amplify-lambda-node24-upgrade](./amplify-lambda-node24-upgrade) | Upgrade an AWS Amplify (Gen 1 or Gen 2) backend Lambda function from the Node.js 20 runtime to Node.js 24, including the runtime config change and the required source fixes (callback handlers, unresolved promises, removed context APIs) |
 | [blackbaud-renxt-api](./blackbaud-renxt-api) | Blackbaud Raiser's Edge NXT SKY API integration reference for nonprofit fundraising and donor management |
 | [bloomerang-api](./bloomerang-api) | Bloomerang CRM API integration reference for donor management features |
 | [donorperfect-api](./donorperfect-api) | DonorPerfect Online XML API integration reference for donor management, gifts, pledges, tributes, and EFT |
@@ -22,6 +23,20 @@ npx skills add asebesta/claude-skills/<skill-name>
 | [veo-video](./veo-video) | Generate videos using Google's Veo 3.1 API via the @google/genai SDK |
 | [trmnl-plugins](./trmnl-plugins) | Build custom private plugins and dashboards for TRMNL e-ink displays (incl. TRMNL X): data strategies, Liquid templating, and Design Framework 3.1 markup |
 | [virtuous-api](./virtuous-api) | Virtuous CRM API integration reference for donor management features |
+
+### amplify-lambda-node24-upgrade
+
+Migrate AWS Amplify backend Lambda functions from the Node.js 20 runtime (`nodejs20.x`) to Node.js 24 (`nodejs24.x`). Use when upgrading or bumping the Node runtime of an Amplify Gen 1 or Gen 2 function, or when a function breaks after moving to `nodejs24.x`. Covers locating the runtime setting (Gen 1 CloudFormation template, Gen 2 `defineFunction` / CDK escape hatch) plus the source-code changes the new runtime forces: removed callback-style handlers, removed `context.callbackWaitsForEmptyEventLoop` / `succeed` / `fail` / `done`, the "Lambda no longer waits for unresolved promises" behavior, and Node 20→24 language changes. Includes an audit script that flags every breaking pattern by file:line.
+
+**Install:**
+```bash
+npx skills add asebesta/claude-skills/amplify-lambda-node24-upgrade
+```
+
+**Triggers on:**
+- Upgrading an Amplify Gen 1/Gen 2 Lambda from Node 20 (or 18/22) to Node 24
+- `nodejs24.x`, `defineFunction({ runtime })`, or callback handlers breaking after a runtime bump
+- Auditing an Amplify backend for Node 24 runtime compatibility
 
 ### blackbaud-renxt-api
 

--- a/amplify-lambda-node24-upgrade/SKILL.md
+++ b/amplify-lambda-node24-upgrade/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: amplify-lambda-node24-upgrade
+description: Upgrade an AWS Amplify backend Lambda function from the Node.js 20 runtime (nodejs20.x) to Node.js 24 (nodejs24.x), including the runtime config change AND the source-code fixes the new runtime requires. Use when a user wants to migrate, bump, or upgrade an Amplify (Gen 1 or Gen 2) Lambda function — or a whole Amplify backend — from Node 20 (or 18/22) to Node 24, or asks why a function broke after moving to nodejs24.x. Covers locating the runtime setting in Amplify Gen 1 (cloudformation-template.json) and Gen 2 (defineFunction runtime / CDK escape hatch), the removed callback-style handler API, the removed context.callbackWaitsForEmptyEventLoop / context.succeed/fail/done, the "Lambda no longer waits for unresolved promises" behavior change, and Node 20→24 language/V8 breaking changes (crypto.createCipher, url.parse, SlowBuffer, AL2023 base image, @types/node, esbuild target). Triggers on Amplify + Lambda + Node 20/24, nodejs24.x, defineFunction runtime, or "callback handler stopped working after Node 24".
+---
+
+# Amplify Lambda: Node 20 → Node 24 Upgrade
+
+Upgrade an AWS Amplify backend Lambda function from `nodejs20.x` to `nodejs24.x`. A correct upgrade is **two parts**: (1) flip the runtime in the Amplify config, and (2) fix the source code, because the Node 24 Lambda runtime ships a new Runtime Interface Client that **removes the callback-style handler API** and **no longer waits for unresolved promises**. Skipping part 2 produces functions that deploy fine but fail or silently drop work at invocation time.
+
+Run this process **per function**. A repo may contain many functions in different states; do not assume they are uniform.
+
+## Workflow
+
+1. **Detect the Amplify generation and locate the runtime setting** — see [references/amplify-config.md](references/amplify-config.md). Confirm the function is actually on Node 20 (or 18/22) before changing anything.
+2. **Audit the handler source for breaking changes** *before* flipping the runtime, so you know the blast radius. Run the audit script:
+   ```bash
+   scripts/audit_node24.sh <path-to-function-or-repo>
+   ```
+   It greps for every pattern the new runtime breaks and prints file:line hits. Treat each hit as a required code review, not an auto-fix.
+3. **Flip the runtime and shared toolchain — centrally, once.** Do these in the orchestrator (not delegated), because they touch shared files and config that parallel fixers would clobber:
+   - Flip the runtime to Node 24 in the Amplify config (Gen 1 or Gen 2 — see amplify-config.md). For Gen 2 this is `runtime: 24`; it is natively supported, so **upgrade `@aws-amplify/backend` rather than dropping to the CDK escape hatch**.
+   - `package.json` → `"engines": { "node": ">=24" }` if present; `@types/node` → `^24` (dev dependency); esbuild/bundler `target` → `node24` (or `es2023`+); tsconfig `target`/`lib` if it pins an older version.
+4. **Fix each function's source by delegating to a subagent** — don't hand-edit handler code inline. For each function, fill the brief in [references/fix-brief.md](references/fix-brief.md) with that function's directory, its audit hits, and the absolute path to breaking-changes.md, then spawn a subagent (general-purpose) with the filled brief. Each subagent fixes only its own function dir and returns a structured report. The two changes that break the most real Amplify functions, and that the brief makes the subagent hunt for:
+   - **Callback-style handlers** → convert to `async`.
+   - **Fire-and-forget promises** (logging, metrics, analytics, DynamoDB writes not `await`ed) → `await` them, because Lambda no longer drains the event loop. This one isn't greppable — it requires reading the handler, which is why a focused subagent does it well.
+
+   For a repo with **many** functions and the user opted into orchestration, use the Workflow pipeline variant in fix-brief.md (audit → fix per function, no barrier). Otherwise spawn subagents directly with the Agent tool. Aggregate every report's `verify` and `unresolved` items for the user.
+5. **Build and test locally**, then deploy:
+   - Gen 2: `npx ampx sandbox` (or the pipeline) — watch for type errors from the new `@types/node`.
+   - Gen 1: `amplify push`.
+   - Invoke the function (real event or `ampx sandbox` / `amplify mock function`) and confirm any background work (writes, logs, metrics) actually completes — this is where the "no longer waits for promises" change bites and tests must explicitly cover it.
+6. **Report** what changed and what the user must verify — fold in every subagent report's `verify` and `unresolved` items (especially async side-effects and any `crypto.createCipher` / `url.parse` usages that need real refactoring).
+
+## The non-negotiable breaking changes (Node 24 Lambda)
+
+These come from the new runtime, independent of language version. Full detail + fix patterns in [references/breaking-changes.md](references/breaking-changes.md).
+
+| Removed / changed | Symptom | Fix |
+|---|---|---|
+| `handler(event, context, callback)` callback signature | `callback is not a function` / function hangs to timeout | Convert to `async (event, context) => { return result }`; `throw` instead of `callback(err)` |
+| `context.callbackWaitsForEmptyEventLoop` | Property gone; background work dropped | Remove the line; `await` all async side-effects |
+| `context.succeed()` / `context.fail()` / `context.done()` | `not a function` | `return` / `throw` from an async handler |
+| Lambda **no longer waits for unresolved promises** | Logs/metrics/DB writes silently missing | `await` every promise whose completion matters before returning |
+
+Response streaming (`awslambda.streamifyResponse(async (event, responseStream, context) => …)`) is unchanged.
+
+## Notes for running across many repos
+
+- **Never blanket-replace.** Changing the runtime string is safe; rewriting handlers is not. Audit first, fix deliberately.
+- A function can be **Gen 1 and Gen 2 in the same monorepo** — detect per function (amplify-config.md explains the tells).
+- `defineFunction({ runtime: 24 })` is natively supported (`NodeVersion = 18 | 20 | 22 | 24`) on `@aws-amplify/backend-function ≥ 1.17.0`. If `24` is rejected, **upgrade `@aws-amplify/backend` + `@aws-amplify/backend-cli`** — that's the fix, not the CDK escape hatch (which is reserved for custom CDK functions). Never silently downgrade the target.
+- ESM/CommonJS, OpenSSL, and AL2023 base-image (`yum`→`dnf`) concerns only matter for container-image functions or functions that pin module type — covered in breaking-changes.md.

--- a/amplify-lambda-node24-upgrade/SKILL.md
+++ b/amplify-lambda-node24-upgrade/SKILL.md
@@ -31,6 +31,16 @@ Run this process **per function**. A repo may contain many functions in differen
    - Invoke the function (real event or `ampx sandbox` / `amplify mock function`) and confirm any background work (writes, logs, metrics) actually completes — this is where the "no longer waits for promises" change bites and tests must explicitly cover it.
 6. **Report** what changed and what the user must verify — fold in every subagent report's `verify` and `unresolved` items (especially async side-effects and any `crypto.createCipher` / `url.parse` usages that need real refactoring).
 
+## Report-only mode (audit any repo, change nothing)
+
+When the goal is just to assess a repo's Node-24 readiness — not to upgrade it — run the audit in report mode and stop:
+
+```bash
+scripts/audit_node24.sh --report <repo-path>
+```
+
+This makes **zero changes** and spawns **no fixer**. It prints a consolidated rollup — Amplify generation(s) detected, function counts, current runtime inventory (how many on 20 vs 18/22 vs already 24), per-category finding counts, and a verdict — followed by the file:line details. Use it to triage many repos, attach to a ticket/PR, or decide which functions are worth upgrading. To actually upgrade, switch to the full workflow above (steps 3–6); do **not** run the fixer in this mode.
+
 ## The non-negotiable breaking changes (Node 24 Lambda)
 
 These come from the new runtime, independent of language version. Full detail + fix patterns in [references/breaking-changes.md](references/breaking-changes.md).

--- a/amplify-lambda-node24-upgrade/references/amplify-config.md
+++ b/amplify-lambda-node24-upgrade/references/amplify-config.md
@@ -1,0 +1,107 @@
+# Locating & changing the Amplify Lambda runtime
+
+First decide **Gen 1 vs Gen 2**, then change the runtime in the right place. Both can coexist in one monorepo — check per function.
+
+## Detecting the generation
+
+| Tell | Generation |
+|---|---|
+| `amplify/backend/function/<name>/` with a `*-cloudformation-template.json` | **Gen 1** |
+| `amplify/backend.ts` and `amplify/functions/<name>/resource.ts` using `defineFunction` | **Gen 2** |
+| `amplify/team-provider-info.json`, `amplify/cli.json` present | Gen 1 |
+| `@aws-amplify/backend` in `package.json`, `ampx` scripts | Gen 2 |
+
+Quick probe:
+```bash
+ls amplify/backend.ts 2>/dev/null && echo "Gen 2"
+ls amplify/backend/ 2>/dev/null && echo "Gen 1"
+grep -rl "defineFunction" amplify 2>/dev/null   # Gen 2 functions
+```
+
+---
+
+## Gen 2 — `defineFunction({ runtime })`
+
+The runtime is a **number** (the Node major version) in `amplify/functions/<name>/resource.ts`:
+
+```ts
+import { defineFunction } from '@aws-amplify/backend';
+
+export const myFn = defineFunction({
+  name: 'my-fn',
+  entry: './handler.ts',
+  runtime: 24,        // ← was 20; Node major version as a number → nodejs24.x
+});
+```
+
+**`runtime: 24` is a first-class, supported value — prefer it and do not reach for the CDK escape hatch.** The accepted type is:
+```ts
+type NodeVersion = 18 | 20 | 22 | 24;   // defineFunction's runtime
+```
+which maps internally to `Runtime.NODEJS_24_X` (`nodejs24.x`). The only reason `24` would be rejected is an outdated dependency, which is fixable by upgrading — not by escaping to CDK.
+
+**Version requirements (the actual gate):**
+- `@aws-amplify/backend-function` **≥ 1.17.0** — the release that added `24` to the `NodeVersion` union (it also moved the default from "oldest LTS" to **22**). This is a transitive dep of `@aws-amplify/backend`.
+- `aws-cdk-lib` **≥ 2.225.0** — the release that added `Runtime.NODEJS_24_X`.
+
+**Check before editing, then fix by upgrading (not escaping):**
+```bash
+npm ls @aws-amplify/backend-function aws-cdk-lib    # see resolved versions
+# if either is too old:
+npm i @aws-amplify/backend@latest @aws-amplify/backend-cli@latest
+```
+A type error on `runtime: 24` means "upgrade the package," full stop. Don't silently downgrade the target or hand-roll the runtime.
+
+Other notes:
+- Default when omitted is **22** on current versions (historically the oldest supported LTS) — so a function with no `runtime` is *not* necessarily on 20. Set `runtime: 24` explicitly.
+- Gen 2 bundles with esbuild internally; still set `@types/node@^24` and any custom esbuild `target` (see breaking-changes.md B6).
+- Historical gotcha (now resolved): early `aws-cdk-lib` 2.224–2.225 could fail bundling a `NodejsFunction` by trying to pull a not-yet-published `sam/build-nodejs24.x` image. If a bundle step fails fetching that image, update `aws-cdk-lib` to a current version — it exists now.
+
+### CDK escape hatch — last resort only
+
+Only needed for a **custom CDK function** (defined directly with `aws-cdk-lib/aws-lambda`'s `Function`, not `defineFunction`), or a genuinely un-upgradable pinned dependency. For a standard `defineFunction`, use `runtime: 24` instead of this.
+
+```ts
+// Custom CDK Function — set runtime directly in its props:
+import { Runtime } from 'aws-cdk-lib/aws-lambda';
+new Function(stack, 'MyFn', { runtime: Runtime.NODEJS_24_X, /* … */ });
+
+// Override on a defineFunction resource (avoid unless runtime: 24 is truly unavailable):
+const cfnFn = backend.myFn.resources.lambda.node.defaultChild as
+  import('aws-cdk-lib/aws-lambda').CfnFunction;
+cfnFn.runtime = Runtime.NODEJS_24_X.name; // 'nodejs24.x'
+```
+
+---
+
+## Gen 1 — CloudFormation template
+
+The runtime lives in the function's CloudFormation template:
+
+```
+amplify/backend/function/<name>/<name>-cloudformation-template.json
+```
+
+Find the `Runtime` property on the Lambda resource and change it:
+
+```json
+"Resources": {
+  "LambdaFunction": {
+    "Type": "AWS::Lambda::Function",
+    "Properties": {
+      "Runtime": "nodejs24.x"   // ← was "nodejs20.x"
+    }
+  }
+}
+```
+
+Then:
+- If a `amplify/backend/function/<name>/src/package.json` has an `"engines"` field, bump it to `>=24`.
+- Run `amplify push` to deploy. (`amplify update function` may rewrite the template; editing the JSON directly is reliable for a runtime bump.)
+- Some Gen 1 functions are written as Lambda **layers** or use a `parameters.json`; the `Runtime` string is still the CloudFormation property to change.
+
+---
+
+## After changing the runtime (both gens)
+
+The config change alone is insufficient — apply the source-code fixes in [breaking-changes.md](breaking-changes.md) (callback handlers, unresolved promises, removed `context.*`). Deploy, then invoke and confirm background side-effects complete.

--- a/amplify-lambda-node24-upgrade/references/breaking-changes.md
+++ b/amplify-lambda-node24-upgrade/references/breaking-changes.md
@@ -1,0 +1,157 @@
+# Node 20 → 24 breaking changes & fix patterns
+
+Two layers of change apply when moving an Amplify Lambda from `nodejs20.x` to `nodejs24.x`:
+
+- **A. Lambda runtime API changes** — from Lambda's new TypeScript Runtime Interface Client (RIC) in `nodejs24.x`. These break code that ran fine on `nodejs20.x`. **Highest priority.**
+- **B. Node.js language / V8 changes** — Node 24 ships V8 13.6, npm 11, and removes/deprecates several APIs vs Node 20.
+
+## Table of contents
+- [A1. Callback-style handlers removed](#a1-callback-style-handlers-removed)
+- [A2. Lambda no longer waits for unresolved promises](#a2-lambda-no-longer-waits-for-unresolved-promises)
+- [A3. context.succeed / fail / done removed](#a3-contextsucceed--fail--done-removed)
+- [A4. callbackWaitsForEmptyEventLoop removed](#a4-callbackwaitsforemptyeventloop-removed)
+- [A5. Response streaming (unchanged)](#a5-response-streaming-unchanged)
+- [B1. crypto.createCipher / createDecipher removed](#b1-cryptocreatecipher--createdecipher-removed)
+- [B2. url.parse() runtime-deprecated](#b2-urlparse-runtime-deprecated)
+- [B3. SlowBuffer / new Buffer() / tls.createSecurePair removed](#b3-slowbuffer--new-buffer--tlscreatesecurepair-removed)
+- [B4. AL2023 base image (container functions only)](#b4-al2023-base-image-container-functions-only)
+- [B5. ESM / require(esm) / module type](#b5-esm--requireesm--module-type)
+- [B6. Toolchain: @types/node, esbuild target, engines](#b6-toolchain-typesnode-esbuild-target-engines)
+- [B7. AWS SDK version](#b7-aws-sdk-version)
+
+---
+
+## A1. Callback-style handlers removed
+
+The new RIC **removes the 3-argument callback signature** `handler(event, context, callback)`. There is no `callback` to invoke — calls throw `callback is not a function`, or the function hangs until timeout.
+
+**Before (CommonJS callback):**
+```js
+exports.handler = (event, context, callback) => {
+  doWork(event, (err, result) => {
+    if (err) return callback(err);
+    callback(null, { statusCode: 200, body: JSON.stringify(result) });
+  });
+};
+```
+
+**After (async):**
+```js
+exports.handler = async (event, context) => {
+  const result = await doWorkAsync(event); // promisify if the dep is callback-only
+  return { statusCode: 200, body: JSON.stringify(result) };
+};
+```
+
+Rules:
+- `callback(null, x)` → `return x`.
+- `callback(err)` → `throw err` (Lambda marks the invocation failed and serializes the error).
+- A callback-only dependency: wrap with `util.promisify`, or `await new Promise((resolve, reject) => fn((e, r) => e ? reject(e) : resolve(r)))`.
+- ESM equivalent: `export const handler = async (event, context) => { … }`.
+- A **synchronous** handler `(event, context) => result` is still valid for purely-sync work — but most handlers do I/O and should be `async`.
+
+## A2. Lambda no longer waits for unresolved promises
+
+On `nodejs24.x`, once the handler returns (or the response stream ends), Lambda **freezes the execution environment immediately**. It does not wait for the event loop to drain. Any promise not `await`ed may never finish — and may resume on a *later, unrelated* invocation (frozen/thawed sandbox), corrupting that invocation.
+
+This is the most insidious change because it deploys cleanly and only manifests as **missing side-effects**: analytics events, structured logs, metric flushes, SNS/SQS/EventBridge publishes, DynamoDB/RDS writes, cache warms.
+
+**Before (fire-and-forget — silently dropped):**
+```js
+exports.handler = async (event) => {
+  logger.flush();                 // returns a promise, not awaited
+  analytics.track('invoked');     // returns a promise, not awaited
+  return respond(event);
+};
+```
+
+**After:**
+```js
+exports.handler = async (event) => {
+  const result = await respond(event);
+  await Promise.all([logger.flush(), analytics.track('invoked')]); // await what must complete
+  return result;
+};
+```
+
+Audit every call that returns a promise and is not `await`ed / `return`ed. If completion genuinely doesn't matter, leave it but add a comment so the next reader knows it's intentional.
+
+> Historically this was masked by `context.callbackWaitsForEmptyEventLoop = true` (the default). That property is gone (A4) and the wait behavior with it.
+
+## A3. context.succeed / fail / done removed
+
+Legacy terminators `context.succeed(result)`, `context.fail(error)`, `context.done(err, result)` are removed (`not a function`).
+
+| Old | New (inside `async` handler) |
+|---|---|
+| `context.succeed(result)` | `return result` |
+| `context.fail(error)` | `throw error` |
+| `context.done(null, result)` | `return result` |
+| `context.done(error)` | `throw error` |
+
+## A4. callbackWaitsForEmptyEventLoop removed
+
+`context.callbackWaitsForEmptyEventLoop` no longer exists. Delete any assignment to it (commonly `context.callbackWaitsForEmptyEventLoop = false`, often paired with DB connection reuse). Removing the line is safe; just ensure side-effects you care about are `await`ed (A2). Reading the property yields `undefined` — code branching on it should be removed.
+
+## A5. Response streaming (unchanged)
+
+`awslambda.streamifyResponse(async (event, responseStream, context) => { … responseStream.end(); })` works the same on `nodejs24.x`. Background work after `responseStream.end()` is **not** awaited — same rule as A2.
+
+---
+
+## B1. crypto.createCipher / createDecipher removed
+
+`crypto.createCipher()` / `crypto.createDecipher()` (password-derived, no explicit IV) are removed and throw. Migrate to the IV-based APIs:
+
+```js
+// Before
+const cipher = crypto.createCipher('aes-256-cbc', password);
+// After — derive a key + random IV explicitly
+const key = crypto.scryptSync(password, salt, 32);
+const iv = crypto.randomBytes(16);
+const cipher = crypto.createCipheriv('aes-256-cbc', key, iv); // store/transmit iv with ciphertext
+```
+This is a **real refactor** (the wire format changes — old ciphertext won't decrypt with the new API). Flag it to the user rather than mechanically swapping.
+
+## B2. url.parse() runtime-deprecated
+
+The legacy `url.parse()` still works on Node 24 but emits a `DeprecationWarning` to stderr on every call (log noise on hot paths). Prefer the WHATWG `URL`:
+```js
+// Before
+const { hostname, pathname, query } = url.parse(input, true);
+// After
+const u = new URL(input);                    // requires an absolute URL or a base
+const params = u.searchParams;               // replaces parsed `query`
+```
+Note semantic differences: `new URL()` requires an absolute URL (or a base), and `query` becomes `URLSearchParams`. Not a hard break — fix opportunistically, especially in high-volume handlers.
+
+## B3. SlowBuffer / new Buffer() / tls.createSecurePair removed
+
+- `SlowBuffer` is removed → use `Buffer.allocUnsafeSlow(size)`.
+- `new Buffer(...)` (already deprecated) → `Buffer.from(...)` / `Buffer.alloc(...)`.
+- `tls.createSecurePair` removed → use `tls.TLSSocket`.
+
+These are rare in app code but common in older transitive deps — if a dep throws on one of these, bump the dep.
+
+## B4. AL2023 base image (container functions only)
+
+`nodejs24.x` is based on **Amazon Linux 2023**. Only relevant if the function is packaged as a **container image** (custom `Dockerfile` from `public.ecr.aws/lambda/nodejs:24`) — not for standard zip-based Amplify functions. In a Dockerfile, replace `yum` with `dnf`/`microdnf`, and re-verify any native binaries/`.so` deps against AL2023's glibc. Standard Amplify `defineFunction` / Gen 1 zip functions are unaffected.
+
+## B5. ESM / require(esm) / module type
+
+- Node 24 can `require()` synchronous ES modules, easing mixed CJS/ESM repos — generally a non-event for migration.
+- If a handler file uses `import`/`export`, ensure it's resolved as ESM: package.json `"type": "module"`, a `.mjs` extension, or the bundler emits ESM. Mismatches surface as `Cannot use import statement outside a module` or `require is not defined`.
+- Don't switch a working CJS function to ESM as part of a runtime bump — keep changes minimal.
+
+## B6. Toolchain: @types/node, esbuild target, engines
+
+Align build tooling with the runtime, or you get phantom type errors / down-leveled output:
+- `@types/node` → `^24` (devDependency). The new types are what surface removed-API usage at compile time.
+- esbuild / bundler `target` → `node24` (Amplify Gen 2 bundles with esbuild under the hood; for custom build steps set `--target=node24`).
+- tsconfig `target`/`lib` → at least `ES2023` if currently pinned lower (so `using`, `Float16Array`, `RegExp.escape`, etc. type-check).
+- `package.json` `"engines": { "node": ">=24" }` if the field exists.
+- npm 11 ships with the runtime; if you pin npm in CI, verify compatibility.
+
+## B7. AWS SDK version
+
+`nodejs20.x` and `nodejs24.x` both bundle **AWS SDK for JavaScript v3** — no v2→v3 migration is introduced by this bump (that only applies coming from nodejs16.x or earlier). Best practice remains: **bundle your own `@aws-sdk/*` dependencies** rather than relying on the runtime-provided copy, so the SDK version is pinned and deterministic across runtime updates. If the function still imports the v2 `aws-sdk` package, that's a separate (larger) migration — call it out.

--- a/amplify-lambda-node24-upgrade/references/fix-brief.md
+++ b/amplify-lambda-node24-upgrade/references/fix-brief.md
@@ -1,0 +1,75 @@
+# Fix brief — hand this to a per-function fix subagent
+
+This is a **template the orchestrator fills in and passes to a subagent** (one subagent per function). It packages the requisite info so the subagent can fix one function's source without re-reading the whole skill or guessing scope. The fixes are judgment calls — the brief gives the subagent the rules and guardrails, not a find-and-replace script.
+
+## Why delegate instead of fixing inline
+
+- **Isolation of context.** Each function's audit hits, handler code, and verification notes stay in their own agent — the orchestrator keeps only the structured report, not every file dump.
+- **Scope safety across a repo.** The orchestrator owns shared files (root `package.json`, `amplify/backend.ts`) and config flips; each subagent touches only its function's source. This prevents parallel agents from clobbering each other's edits to shared files.
+- **Parallelism.** Many functions → many subagents (or a Workflow pipeline) at once.
+
+## How the orchestrator uses it
+
+1. Do the **shared/config work once, centrally** (don't delegate these): flip the runtime (`runtime: 24` / `nodejs24.x`), bump `@types/node@^24`, `engines.node`, esbuild `target`, and verify `@aws-amplify/backend-function ≥ 1.17.0` (see amplify-config.md).
+2. For each function, fill the placeholders below and spawn a subagent (general-purpose) with the filled brief as its prompt. Pass the **absolute path** to `breaking-changes.md` so the subagent reads the full catalog.
+3. Collect each subagent's structured report; aggregate the `verify` and `unresolved` items into the final summary to the user.
+
+---
+
+## Brief template (fill the `{{…}}` placeholders, then send as the subagent prompt)
+
+> **Task: migrate one AWS Amplify Lambda's source for the Node.js 24 runtime.**
+>
+> You are fixing the source code of a single Lambda function so it runs correctly on the `nodejs24.x` runtime. The runtime/config and shared toolchain files have already been updated by the orchestrator — **do not edit** `{{REPO_ROOT}}/package.json`, `{{AMPLIFY_BACKEND_TS}}`, or any file outside the function directory. Scope every edit to:
+>
+> - Function directory: `{{FUNCTION_DIR}}`
+> - Amplify generation: `{{GEN}}` (Gen 1 / Gen 2)
+>
+> **Read first:** the complete breaking-changes catalog at `{{BREAKING_CHANGES_ABS_PATH}}`. It has the before→after fix patterns for every item below.
+>
+> **Audit hits already found in this function** (each is a required review, line numbers may shift as you edit):
+> ```
+> {{AUDIT_OUTPUT_FOR_THIS_FUNCTION}}
+> ```
+>
+> **Apply these fixes, preserving existing behavior:**
+> 1. **Callback handlers** → convert `handler(event, context, callback)` to `async (event, context)`. `callback(null, x)` → `return x`; `callback(err)` → `throw err`. Promisify any callback-only dependency the handler awaits.
+> 2. **Unresolved promises (most important, not greppable)** — read the handler end-to-end and find every promise that is NOT awaited or returned: logging/flush, analytics/metrics, SNS/SQS/EventBridge publishes, DynamoDB/RDS writes, cache warms. `await` everything whose completion matters; Lambda no longer drains the event loop, so unawaited work is silently dropped. If a fire-and-forget is genuinely intentional, leave it and add a one-line comment saying so.
+> 3. **Removed `context` APIs** — delete `context.callbackWaitsForEmptyEventLoop = …`; replace `context.succeed(x)`→`return x`, `context.fail(e)`→`throw e`, `context.done(e,x)`→`throw e`/`return x`.
+> 4. **Removed/deprecated Node APIs** — `crypto.createCipher`/`createDecipher` (DO NOT mechanically swap — the wire format changes; flag as unresolved with a proposed `createCipheriv` approach), `new Buffer()`→`Buffer.from`/`alloc`, `SlowBuffer`, `tls.createSecurePair`, and `url.parse()`→`new URL()` where low-risk.
+>
+> **Guardrails:**
+> - Make the **minimum** change that satisfies each rule. Do not refactor unrelated code, reformat, or "modernize" beyond what the runtime requires.
+> - Do not change the handler's public contract (event shape in, response shape out).
+> - If a fix requires a behavioral decision you can't make safely (e.g. encryption format, whether a side-effect must block the response), DON'T guess — record it under `unresolved`.
+> - After editing, run the function's typecheck/build if one exists (`tsc --noEmit`, the package's build script, or `npx ampx sandbox` is too heavy — prefer typecheck). Report the result; do not deploy.
+>
+> **Return ONLY this report (no prose preamble):**
+> ```
+> function: {{FUNCTION_DIR}}
+> changes:
+>   - file: <path>  rule: <A1|A2|A3|A4|B1|B2|B3>  summary: <what changed, one line>
+> unresolved:        # decisions for a human — empty list if none
+>   - file: <path>  issue: <why it needs a human>  proposal: <suggested fix>
+> verify:            # what the user must confirm at runtime
+>   - <side-effect / behavior to test, e.g. "analytics.track now awaited — confirm events still emit">
+> build: <pass | fail: summary | not-run: reason>
+> ```
+
+---
+
+## Many functions: Workflow variant
+
+When a repo has many functions and the user has opted into orchestration, pipeline the work instead of spawning agents one by one. Audit and fix flow per-function with no barrier; shared/config edits stay in the orchestrator before the pipeline runs.
+
+```js
+// sketch — fill auditOutput per function from scripts/audit_node24.sh
+const reports = await pipeline(
+  functionDirs,
+  dir => agent(auditPromptFor(dir), { label: `audit:${dir}`, phase: 'Audit', schema: AUDIT_SCHEMA }),
+  (audit, dir) => agent(fillBrief(dir, audit), { label: `fix:${dir}`, phase: 'Fix', schema: REPORT_SCHEMA }),
+);
+// orchestrator aggregates reports[].verify and reports[].unresolved for the user
+```
+
+Worktree isolation is NOT needed: each subagent edits only its own function directory, and the orchestrator already handled the shared files.

--- a/amplify-lambda-node24-upgrade/scripts/audit_node24.sh
+++ b/amplify-lambda-node24-upgrade/scripts/audit_node24.sh
@@ -1,13 +1,24 @@
 #!/usr/bin/env bash
 # Audit an Amplify Lambda function (or whole repo) for code that the Node.js 24
 # Lambda runtime (nodejs24.x) breaks or deprecates. Prints file:line hits grouped
-# by issue. Read-only — fixes nothing. Each hit is a required manual review.
+# by issue. ALWAYS read-only — fixes nothing. Each hit is a required manual review.
 #
-# Usage: audit_node24.sh <path>     (defaults to current directory)
+# Usage:
+#   audit_node24.sh <path>              Detail hits (default; used by the fix workflow)
+#   audit_node24.sh --report <path>     Report-only repo audit: a consolidated rollup
+#                                       (generation + runtime inventory + issue counts +
+#                                       verdict) followed by detail. Changes nothing —
+#                                       does NOT trigger any fixing. Good for "just
+#                                       audit this repo". <path> defaults to "."
 #
 # Companion docs: ../references/breaking-changes.md  ../references/amplify-config.md
 
 set -euo pipefail
+
+REPORT=0
+case "${1:-}" in
+  -r|--report) REPORT=1; shift ;;
+esac
 ROOT="${1:-.}"
 
 if [ ! -e "$ROOT" ]; then
@@ -28,66 +39,131 @@ else
       "$1" "$ROOT" 2>/dev/null || true; }
 fi
 
+count_lines() { [ -z "$1" ] && echo 0 || { printf '%s\n' "$1" | grep -c . || true; }; }
+
 found_any=0
+issue_total=0
+summary=""   # newline-accumulated "  [TAG] title — N"
+
+# section <tag-is-issue:0|1> <title> <pattern> <note>
 section() {
-  local title="$1" pattern="$2" note="$3"
-  local hits; hits="$(search "$pattern")"
-  if [ -n "$hits" ]; then
+  local is_issue="$1" title="$2" pattern="$3" note="$4"
+  local hits n; hits="$(search "$pattern")"; n="$(count_lines "$hits")"
+  if [ "$n" -gt 0 ]; then
     found_any=1
-    printf '\n### %s\n%s\n' "$title" "$note"
-    printf '%s\n' "$hits"
+    [ "$is_issue" = "1" ] && issue_total=$((issue_total + n))
+    summary="${summary}  ${title} — ${n}"$'\n'
+    DETAILS="${DETAILS}"$'\n'"### ${title}"$'\n'"${note}"$'\n'"${hits}"$'\n'
   fi
 }
 
-echo "== Node 24 Lambda upgrade audit: $ROOT =="
-echo "(no changes made — review each hit against references/breaking-changes.md)"
+DETAILS=""
 
 # --- A. Lambda runtime API removals (highest priority) ---
-section "[A1] Callback-style handler signature (REMOVED)" \
+section 1 "[A1] Callback-style handler signature (REMOVED)" \
   '\(\s*event\s*,\s*context\s*,\s*callback\s*\)' \
   "→ Convert handler to async; return instead of callback(null,x), throw instead of callback(err)."
 
-section "[A1] Other callback-style function signatures" \
+section 1 "[A1] Other callback-style function signatures" \
   '\(\s*err\s*,\s*[A-Za-z_]+\s*\)\s*=>|function\s*\(\s*err\s*,' \
   "→ Possible callback patterns; promisify any callback-only deps used in the handler."
 
-section "[A4] context.callbackWaitsForEmptyEventLoop (REMOVED)" \
+section 1 "[A4] context.callbackWaitsForEmptyEventLoop (REMOVED)" \
   'callbackWaitsForEmptyEventLoop' \
   "→ Delete the line; ensure background work is awaited (see A2)."
 
-section "[A3] context.succeed / fail / done (REMOVED)" \
+section 1 "[A3] context.succeed / fail / done (REMOVED)" \
   'context\.(succeed|fail|done)\s*\(' \
   "→ return (succeed/done-result), throw (fail/done-error) from an async handler."
 
 # --- B. Node 24 / V8 language removals & deprecations ---
-section "[B1] crypto.createCipher / createDecipher (REMOVED — throws)" \
+section 1 "[B1] crypto.createCipher / createDecipher (REMOVED — throws)" \
   'createCipher\s*\(|createDecipher\s*\(' \
   "→ Migrate to createCipheriv/createDecipheriv (real refactor — wire format changes)."
 
-section "[B2] url.parse() (runtime-deprecated — warns)" \
+section 1 "[B2] url.parse() (runtime-deprecated — warns)" \
   '\burl\.parse\s*\(' \
   "→ Prefer new URL(); note query → URLSearchParams and absolute-URL requirement."
 
-section "[B3] new Buffer() / SlowBuffer / tls.createSecurePair (REMOVED)" \
+section 1 "[B3] new Buffer() / SlowBuffer / tls.createSecurePair (REMOVED)" \
   'new\s+Buffer\s*\(|SlowBuffer|tls\.createSecurePair' \
   "→ Buffer.from/alloc; Buffer.allocUnsafeSlow; tls.TLSSocket. Often inside old deps."
 
-section "[B7] AWS SDK v2 import (separate, larger migration)" \
+section 1 "[B7] AWS SDK v2 import (separate, larger migration)" \
   "require\(['\"]aws-sdk['\"]\)|from\s+['\"]aws-sdk['\"]" \
   "→ Node 24 bundles SDK v3 only. Migrate to @aws-sdk/* and bundle it yourself."
 
-# --- Config: current runtime strings to flip ---
-section "[CONFIG] Existing runtime strings (Gen 1 CloudFormation)" \
+# --- Config: current runtime strings to flip (informational, not counted as code issues) ---
+section 0 "[CONFIG] Existing runtime strings (Gen 1 CloudFormation)" \
   'nodejs(18|20|22)\.x' \
   "→ Change to nodejs24.x in <name>-cloudformation-template.json."
 
-section "[CONFIG] defineFunction runtime (Gen 2)" \
+section 0 "[CONFIG] defineFunction runtime (Gen 2)" \
   'runtime\s*:\s*(18|20|22)\b' \
-  "→ Set runtime: 24 in amplify/functions/<name>/resource.ts (or CDK escape hatch)."
+  "→ Set runtime: 24 in amplify/functions/<name>/resource.ts."
 
-section "[TOOLCHAIN] @types/node / engines pinned below 24" \
+section 0 "[TOOLCHAIN] @types/node / engines pinned below 24" \
   '"@types/node"\s*:\s*"[^"]*1[0-9]|"@types/node"\s*:\s*"[^"]*2[0-3]|"node"\s*:\s*"[^"]*<\s*24' \
   "→ Bump @types/node to ^24 and engines.node to >=24."
+
+# ---------------------------------------------------------------------------
+# Report-only rollup
+# ---------------------------------------------------------------------------
+if [ "$REPORT" = "1" ]; then
+  # Generation detection + function discovery (read-only).
+  gen1_n="$(find "$ROOT" -path '*/amplify/backend/function/*-cloudformation-template.json' \
+            -not -path '*/node_modules/*' 2>/dev/null | wc -l | tr -d ' ')"
+  gen2_files="$(search 'defineFunction' | cut -d: -f1 | sort -u)"
+  gen2_n="$(count_lines "$gen2_files")"
+  rt_20="$(count_lines "$(search 'nodejs20\.x|runtime\s*:\s*20\b')")"
+  rt_18_22="$(count_lines "$(search 'nodejs(18|22)\.x|runtime\s*:\s*(18|22)\b')")"
+  rt_24="$(count_lines "$(search 'nodejs24\.x|runtime\s*:\s*24\b')")"
+
+  gens=""
+  [ "$gen1_n" -gt 0 ] && gens="Gen 1"
+  [ "$gen2_n" -gt 0 ] && gens="${gens:+$gens + }Gen 2"
+  [ -z "$gens" ] && gens="none detected (is this an Amplify repo?)"
+
+  echo "================================================================"
+  echo " Node 24 Lambda upgrade — REPORT-ONLY AUDIT (no files changed)"
+  echo " Path: $ROOT"
+  echo "================================================================"
+  echo
+  echo "## Summary"
+  echo "Amplify generation:   $gens"
+  echo "Functions discovered: Gen 1 = $gen1_n, Gen 2 = $gen2_n"
+  echo "Runtime inventory:    on 20 = $rt_20, on 18/22 = $rt_18_22, already on 24 = $rt_24"
+  echo "Code findings (A/B):  $issue_total total"
+  if [ -n "$summary" ]; then
+    echo "By category:"
+    printf '%s' "$summary"
+  fi
+  echo
+  if [ "$issue_total" -gt 0 ]; then
+    echo "Verdict: NEEDS CODE FIXES — $issue_total greppable finding(s) before this repo is Node-24-safe."
+  else
+    echo "Verdict: no greppable code findings. Still REQUIRES the manual [A2] review below."
+  fi
+  echo
+  echo "## Manual review required (not greppable)"
+  echo "[A2] Fire-and-forget promises: Lambda no longer drains the event loop."
+  echo "     Inspect each handler for promises NOT awaited/returned — logging.flush(),"
+  echo "     analytics/metrics, SNS/SQS/EventBridge publishes, DynamoDB/RDS writes."
+  echo
+  echo "## Details"
+  if [ "$found_any" = "1" ]; then printf '%s\n' "$DETAILS"; else echo "(no greppable patterns)"; fi
+  echo
+  echo "Report-only: this command makes NO changes and does NOT run any fixer."
+  echo "To fix, follow the SKILL.md workflow (audit → flip runtime → delegate fixes)."
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Default (detail) mode — used by the per-function fix workflow
+# ---------------------------------------------------------------------------
+echo "== Node 24 Lambda upgrade audit: $ROOT =="
+echo "(no changes made — review each hit against references/breaking-changes.md)"
+if [ "$found_any" = "1" ]; then printf '%s\n' "$DETAILS"; fi
 
 echo ""
 echo "== Manual review required (not greppable) =="

--- a/amplify-lambda-node24-upgrade/scripts/audit_node24.sh
+++ b/amplify-lambda-node24-upgrade/scripts/audit_node24.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Audit an Amplify Lambda function (or whole repo) for code that the Node.js 24
+# Lambda runtime (nodejs24.x) breaks or deprecates. Prints file:line hits grouped
+# by issue. Read-only — fixes nothing. Each hit is a required manual review.
+#
+# Usage: audit_node24.sh <path>     (defaults to current directory)
+#
+# Companion docs: ../references/breaking-changes.md  ../references/amplify-config.md
+
+set -euo pipefail
+ROOT="${1:-.}"
+
+if [ ! -e "$ROOT" ]; then
+  echo "error: path not found: $ROOT" >&2
+  exit 2
+fi
+
+# Prefer ripgrep; fall back to grep -rn. Both skip node_modules/dist/.git/build.
+if command -v rg >/dev/null 2>&1; then
+  search() { rg -n --no-heading \
+      -g '!node_modules' -g '!dist' -g '!build' -g '!.git' -g '!*.min.js' \
+      -g '*.js' -g '*.mjs' -g '*.cjs' -g '*.ts' -g '*.json' \
+      -e "$1" "$ROOT" 2>/dev/null || true; }
+else
+  search() { grep -rnE \
+      --include='*.js' --include='*.mjs' --include='*.cjs' --include='*.ts' --include='*.json' \
+      --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=build --exclude-dir=.git \
+      "$1" "$ROOT" 2>/dev/null || true; }
+fi
+
+found_any=0
+section() {
+  local title="$1" pattern="$2" note="$3"
+  local hits; hits="$(search "$pattern")"
+  if [ -n "$hits" ]; then
+    found_any=1
+    printf '\n### %s\n%s\n' "$title" "$note"
+    printf '%s\n' "$hits"
+  fi
+}
+
+echo "== Node 24 Lambda upgrade audit: $ROOT =="
+echo "(no changes made — review each hit against references/breaking-changes.md)"
+
+# --- A. Lambda runtime API removals (highest priority) ---
+section "[A1] Callback-style handler signature (REMOVED)" \
+  '\(\s*event\s*,\s*context\s*,\s*callback\s*\)' \
+  "→ Convert handler to async; return instead of callback(null,x), throw instead of callback(err)."
+
+section "[A1] Other callback-style function signatures" \
+  '\(\s*err\s*,\s*[A-Za-z_]+\s*\)\s*=>|function\s*\(\s*err\s*,' \
+  "→ Possible callback patterns; promisify any callback-only deps used in the handler."
+
+section "[A4] context.callbackWaitsForEmptyEventLoop (REMOVED)" \
+  'callbackWaitsForEmptyEventLoop' \
+  "→ Delete the line; ensure background work is awaited (see A2)."
+
+section "[A3] context.succeed / fail / done (REMOVED)" \
+  'context\.(succeed|fail|done)\s*\(' \
+  "→ return (succeed/done-result), throw (fail/done-error) from an async handler."
+
+# --- B. Node 24 / V8 language removals & deprecations ---
+section "[B1] crypto.createCipher / createDecipher (REMOVED — throws)" \
+  'createCipher\s*\(|createDecipher\s*\(' \
+  "→ Migrate to createCipheriv/createDecipheriv (real refactor — wire format changes)."
+
+section "[B2] url.parse() (runtime-deprecated — warns)" \
+  '\burl\.parse\s*\(' \
+  "→ Prefer new URL(); note query → URLSearchParams and absolute-URL requirement."
+
+section "[B3] new Buffer() / SlowBuffer / tls.createSecurePair (REMOVED)" \
+  'new\s+Buffer\s*\(|SlowBuffer|tls\.createSecurePair' \
+  "→ Buffer.from/alloc; Buffer.allocUnsafeSlow; tls.TLSSocket. Often inside old deps."
+
+section "[B7] AWS SDK v2 import (separate, larger migration)" \
+  "require\(['\"]aws-sdk['\"]\)|from\s+['\"]aws-sdk['\"]" \
+  "→ Node 24 bundles SDK v3 only. Migrate to @aws-sdk/* and bundle it yourself."
+
+# --- Config: current runtime strings to flip ---
+section "[CONFIG] Existing runtime strings (Gen 1 CloudFormation)" \
+  'nodejs(18|20|22)\.x' \
+  "→ Change to nodejs24.x in <name>-cloudformation-template.json."
+
+section "[CONFIG] defineFunction runtime (Gen 2)" \
+  'runtime\s*:\s*(18|20|22)\b' \
+  "→ Set runtime: 24 in amplify/functions/<name>/resource.ts (or CDK escape hatch)."
+
+section "[TOOLCHAIN] @types/node / engines pinned below 24" \
+  '"@types/node"\s*:\s*"[^"]*1[0-9]|"@types/node"\s*:\s*"[^"]*2[0-3]|"node"\s*:\s*"[^"]*<\s*24' \
+  "→ Bump @types/node to ^24 and engines.node to >=24."
+
+echo ""
+echo "== Manual review required (not greppable) =="
+echo "[A2] Fire-and-forget promises: Lambda no longer drains the event loop."
+echo "     Inspect the handler for promises that are NOT awaited/returned —"
+echo "     logging.flush(), analytics/metrics, SNS/SQS/EventBridge publishes,"
+echo "     DynamoDB/RDS writes. Await everything whose completion matters."
+
+if [ "$found_any" -eq 0 ]; then
+  echo ""
+  echo "No greppable breaking patterns found. Still review [A2] manually and confirm the runtime string is flipped to nodejs24.x / runtime: 24."
+fi


### PR DESCRIPTION
Adds a skill for migrating AWS Amplify (Gen 1 and Gen 2) backend Lambda functions from the Node.js 20 runtime to Node.js 24.

## What it covers
- **Runtime config** — locating and flipping the setting in Gen 1 (`<name>-cloudformation-template.json`) and Gen 2 (`defineFunction({ runtime: 24 })`, natively supported on `@aws-amplify/backend-function >= 1.17.0` / `aws-cdk-lib >= 2.225.0` — no CDK escape hatch needed for standard functions).
- **Source fixes the new runtime forces** — removed callback-style handlers, removed `context.callbackWaitsForEmptyEventLoop` / `succeed` / `fail` / `done`, and the "Lambda no longer waits for unresolved promises" behavior, plus Node 20→24 language changes (`crypto.createCipher`, `url.parse`, `SlowBuffer`, AL2023 base image, `@types/node`/esbuild target).

## Contents
- `SKILL.md` — per-function workflow: detect gen → audit → flip runtime/toolchain centrally → delegate source fixes → build/test → report.
- `scripts/audit_node24.sh` — flags every breaking pattern by file:line (ripgrep with grep fallback; tested against a fixture).
- `references/breaking-changes.md` — full before→after fix catalog.
- `references/amplify-config.md` — Gen 1 vs Gen 2 detection and runtime location, with version-gate guidance.
- `references/fix-brief.md` — a fill-in brief that delegates per-function code fixes to a subagent, with a Workflow pipeline variant for many-function repos.

Scoped to the amplify skill only; unrelated working-tree WIP was left out of the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)